### PR TITLE
[BugFix] median filter the right pose

### DIFF
--- a/JHMDB/utils.py
+++ b/JHMDB/utils.py
@@ -3,48 +3,52 @@ import os
 import pandas as pd
 import random
 import scipy.ndimage.interpolation as inter
-from scipy.signal import medfilt 
+from scipy.signal import medfilt
 
 ###################################################################################
-    
-    
-#Rescale to be 64 frames
-def zoom(p,target_l=64,joints_num=25,joints_dim=3):
+
+
+# Rescale to be 64 frames
+def zoom(p, target_l=64, joints_num=25, joints_dim=3):
     l = p.shape[0]
-    p_new = np.empty([target_l,joints_num,joints_dim]) 
+    p_new = np.empty([target_l, joints_num, joints_dim])
     for m in range(joints_num):
         for n in range(joints_dim):
-            p_new[:,m,n] = medfilt(p_new[:,m,n],3)
-            p_new[:,m,n] = inter.zoom(p[:,m,n],target_l/l)[:target_l]         
+            p[:, m, n] = medfilt(p[:, m, n], 3)
+            p_new[:, m, n] = inter.zoom(p[:, m, n], target_l / l)[:target_l]
     return p_new
 
-def sampling_frame(p,C):
-    full_l = p.shape[0] # full length
-    if random.uniform(0,1)<0.5: # aligment sampling
-        valid_l = np.round(np.random.uniform(0.85,1)*full_l)
-        s = random.randint(0, full_l-int(valid_l))
-        e = s+valid_l # sample end point
-        p = p[int(s):int(e),:,:]    
-    else: # without aligment sampling
-        valid_l = np.round(np.random.uniform(0.9,1)*full_l)
-        index = np.sort(np.random.choice(range(0,full_l),int(valid_l),replace=False))
-        p = p[index,:,:]
-    p = zoom(p,C.frame_l,C.joint_n,C.joint_d)
+
+def sampling_frame(p, C):
+    full_l = p.shape[0]  # full length
+    if random.uniform(0, 1) < 0.5:  # aligment sampling
+        valid_l = np.round(np.random.uniform(0.85, 1) * full_l)
+        s = random.randint(0, full_l - int(valid_l))
+        e = s + valid_l  # sample end point
+        p = p[int(s):int(e), :, :]
+    else:  # without aligment sampling
+        valid_l = np.round(np.random.uniform(0.9, 1) * full_l)
+        index = np.sort(np.random.choice(
+            range(0, full_l), int(valid_l), replace=False))
+        p = p[index, :, :]
+    p = zoom(p, C.frame_l, C.joint_n, C.joint_d)
     return p
 
+
 def norm_scale(x):
-    return (x-np.mean(x))/np.mean(x)
+    return (x - np.mean(x)) / np.mean(x)
+
 
 from scipy.spatial.distance import cdist
-def get_CG(p,C):
+
+
+def get_CG(p, C):
     M = []
-    iu = np.triu_indices(C.joint_n,1,C.joint_n)
-    for f in range(C.frame_l): 
-        d_m = cdist(p[f],p[f],'euclidean')       
-        d_m = d_m[iu] 
+    iu = np.triu_indices(C.joint_n, 1, C.joint_n)
+    for f in range(C.frame_l):
+        d_m = cdist(p[f], p[f], 'euclidean')
+        d_m = d_m[iu]
         M.append(d_m)
-    M = np.stack(M) 
+    M = np.stack(M)
     M = norm_scale(M)
     return M
-
-


### PR DESCRIPTION
Line 17, 18 seems to be wrong. after the correction:
```
 p[:, m, n] = medfilt(p[:, m, n], 3)
 p_new[:, m, n] = inter.zoom(p[:, m, n], target_l / l)[:target_l]
```
we are doing median filtering them zoom it to processed pose `p_new`